### PR TITLE
HU-2B confirmar los datos basicos del conjunto

### DIFF
--- a/app/application/common/use_case/auth_first_time.py
+++ b/app/application/common/use_case/auth_first_time.py
@@ -1,0 +1,23 @@
+from app.application.common.use_case.schemas.auth import FirstTimeRegisterIn, LoginOut
+from app.infrastructure.db.repositories.usuario_respository import UsuariosRepository
+
+class FirstTimeRegisterUseCase:
+    def __init__(self, users: UsuariosRepository):
+        self.users = users
+
+    def execute(self, payload: FirstTimeRegisterIn) -> LoginOut:
+        user = self.users.upsert_first_time(
+            documento=payload.documento,
+            nombre=payload.nombre,
+            apellidos=payload.apellidos,
+            telefono=payload.telefono,
+            email=payload.email,
+            contrasena=payload.contrasena
+        )
+        nombre_completo = f"{user.nombre.strip()} {user.apellidos.strip()}".strip()
+        return LoginOut(
+            id_usuario=user.id_usuario,
+            email=user.email,
+            nombre_completo=nombre_completo,
+            first_time=True
+        )

--- a/app/application/common/use_case/auth_first_time_register.py
+++ b/app/application/common/use_case/auth_first_time_register.py
@@ -1,0 +1,23 @@
+from app.application.common.use_case.schemas.auth import FirstTimeRegisterIn, LoginOut
+from app.infrastructure.db.repositories.usuario_respository import UsuariosRepository
+
+class FirstTimeRegisterUseCase:
+    def __init__(self, users: UsuariosRepository):
+        self.users = users
+
+    def execute(self, payload: FirstTimeRegisterIn) -> LoginOut:
+        user = self.users.upsert_first_time(
+            documento=payload.documento,
+            nombre=payload.nombre,
+            apellidos=payload.apellidos,
+            telefono=payload.telefono,
+            email=payload.email,
+            contrasena=payload.contrasena
+        )
+        nombre_completo = f"{user.nombre.strip()} {user.apellidos.strip()}".strip()
+        return LoginOut(
+            id_usuario=user.id_usuario,
+            email=user.email,
+            nombre_completo=nombre_completo,
+            first_time=True
+        )

--- a/app/application/common/use_case/schemas/auth.py
+++ b/app/application/common/use_case/schemas/auth.py
@@ -1,0 +1,61 @@
+# app/application/common/use_case/schemas/auth.py
+from typing import Annotated, Optional
+from pydantic import BaseModel, EmailStr, field_validator
+from pydantic.types import StringConstraints as S
+
+# --- Tipos validados ---
+
+# Documento: solo dígitos, 5–30
+Doc = Annotated[str, S(pattern=r'^\d{5,30}$', strip_whitespace=True)]
+
+# Nombre/Apellidos: letras con tildes y ñ, 2–100
+TextoNombre = Annotated[str, S(
+    pattern=r'^[A-Za-zÁÉÍÓÚáéíóúÑñ ]{2,100}$',
+    strip_whitespace=True
+)]
+
+# Teléfono: solo dígitos, 7–15
+Tel = Annotated[str, S(pattern=r'^\d{7,15}$', strip_whitespace=True)]
+
+# Contraseña: mínimo 6, máx 255
+Contrasena = Annotated[str, S(min_length=6, max_length=255, strip_whitespace=True)]
+
+
+# --- DTOs ---
+
+class FirstTimeRegisterIn(BaseModel):
+    documento: Doc
+    nombre: TextoNombre
+    apellidos: TextoNombre
+    telefono: Tel
+    email: EmailStr
+    contrasena: Contrasena
+
+    @field_validator("nombre", "apellidos")
+    @classmethod
+    def collapse_spaces(cls, v: str) -> str:
+        return " ".join(v.split())
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        # devolver string; Pydantic lo valida como EmailStr
+        return v.lower().strip()
+
+
+class LoginIn(BaseModel):
+    email: EmailStr
+    contrasena: Contrasena
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        return v.lower().strip()
+
+
+class LoginOut(BaseModel):
+    id_usuario: int
+    email: Optional[str] = None
+    nombre_completo: str
+    first_time: bool
+    conjunto_residencial_id: Optional[int] = None  

--- a/app/application/common/use_case/schemas/auth_login.py
+++ b/app/application/common/use_case/schemas/auth_login.py
@@ -1,0 +1,29 @@
+from app.application.common.use_case.schemas.auth import LoginIn, LoginOut
+from app.infrastructure.db.repositories.usuario_respository import UsuariosRepository
+
+class AuthLoginUseCase:
+    def __init__(self, repo: UsuariosRepository):
+        self.repo = repo
+
+    def execute(self, payload: LoginIn) -> LoginOut:
+        # Primero intentamos por email (requerimiento actual)
+        user = self.repo.get_by_email_and_pass(payload.email, payload.contrasena)
+
+        # Si aún no tienes email en BD/ORM y quieres permitir login por teléfono como transición, descomenta:
+        # if not user:
+        #     user = self.repo.get_by_phone_and_pass(payload.email, payload.contrasena)  # ojo: aquí email vendría con el teléfono. Solo para pruebas.
+
+        if not user:
+            raise ValueError("Credenciales inválidas")
+
+        # Obtener id de conjunto por JOIN con apartamento
+        conjunto_id = self.repo.get_conjunto_id_for_user(user.id_usuario)
+
+        nombre_completo = f"{user.nombre.strip()} {user.apellidos.strip()}".strip()
+        return LoginOut(
+            id_usuario=user.id_usuario,
+            email=getattr(user, "email", None),  # por si aún no está en el modelo
+            nombre_completo=nombre_completo,
+            first_time=bool(user.first_time),
+            conjunto_residencial_id=conjunto_id,
+        )

--- a/app/application/common/use_case/schemas/setup.py
+++ b/app/application/common/use_case/schemas/setup.py
@@ -1,0 +1,48 @@
+from typing import Annotated, Optional, List
+from pydantic import BaseModel, EmailStr, field_validator
+from pydantic.types import StringConstraints as S
+
+TextoCorto = Annotated[str, S(min_length=2, max_length=100, strip_whitespace=True)]
+Direccion  = Annotated[str, S(min_length=3, max_length=255, strip_whitespace=True)]
+Tel        = Annotated[str, S(pattern=r'^\d{7,15}$', strip_whitespace=True)]
+
+class SetupInitialOut(BaseModel):
+    email: Optional[EmailStr] = None
+    nombre_conjunto: str
+    ciudad: str
+    direccion: Optional[str] = None
+    telefono: Optional[str] = None
+    cantidad_parqueaderos: int
+
+class FieldError(BaseModel):
+    field: str
+    message: str
+    code: str  # "blank" | "format" | "invalid_value"...
+
+class SetupActionResult(BaseModel):
+    status: str       # ok | validation_error | not_found | conflict | error
+    message: str
+    errors: Optional[List[FieldError]] = None
+
+class SetupInitialUpdateIn(BaseModel):
+    id_conjunto: int
+    email: Optional[EmailStr] = None
+    nombre_conjunto: TextoCorto
+    ciudad_id: int
+    direccion: Optional[Direccion] = None
+    telefono: Optional[Tel] = None
+    cantidad_parqueaderos: int
+
+    @field_validator("id_conjunto", "ciudad_id")
+    @classmethod
+    def positive_int(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("Debe ser un entero positivo")
+        return v
+
+    @field_validator("cantidad_parqueaderos")
+    @classmethod
+    def non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("La cantidad de parqueaderos no puede ser negativa")
+        return v

--- a/app/application/common/use_case/setup_initial.py
+++ b/app/application/common/use_case/setup_initial.py
@@ -1,0 +1,66 @@
+from app.application.common.use_case.schemas.setup import (
+    SetupInitialOut, SetupInitialUpdateIn, SetupActionResult, FieldError
+)
+from app.infrastructure.db.repositories.setup_repository import SetupRepository
+
+class SetupInitialGetUseCase:
+    def __init__(self, repo: SetupRepository):
+        self.repo = repo
+
+    def execute(self, id_conjunto: int, id_usuario: int) -> SetupInitialOut:
+        usr, cjto, ciudad_nombre, asignados = self.repo.fetch_initial(id_conjunto, id_usuario)
+        if not cjto:
+            raise ValueError("Conjunto residencial no encontrado")
+
+        return SetupInitialOut(
+            email=getattr(cjto, "email_contacto", None),
+            nombre_conjunto=cjto.nombre_conjunto,
+            ciudad=ciudad_nombre or "",
+            direccion=cjto.direccion_conjunto,
+            telefono=getattr(cjto, "telefono_contacto", None),
+            cantidad_parqueaderos=cjto.numero_apartamentos if cjto.numero_apartamentos is not None else asignados,
+        )
+
+class SetupInitialUpdateUseCase:
+    def __init__(self, repo: SetupRepository):
+        self.repo = repo
+
+    def execute(self, payload: SetupInitialUpdateIn) -> SetupActionResult:
+        # Validación de “espacios en blanco” (string vacía tras strip)
+        errors: list[FieldError] = []
+        def is_blank(s: str | None) -> bool:
+            return s is not None and s.strip() == ""
+
+        if is_blank(payload.nombre_conjunto):
+            errors.append(FieldError(field="nombre_conjunto", code="blank", message="El nombre no puede estar vacío"))
+        if payload.direccion is not None and is_blank(payload.direccion):
+            errors.append(FieldError(field="direccion", code="blank", message="La dirección no puede estar vacía"))
+        if payload.email is not None and is_blank(payload.email):
+            errors.append(FieldError(field="email", code="blank", message="El correo no puede estar vacío"))
+        if payload.telefono is not None and is_blank(payload.telefono):
+            errors.append(FieldError(field="telefono", code="blank", message="El teléfono no puede estar vacío"))
+
+        if errors:
+            return SetupActionResult(status="validation_error", message="Datos inválidos", errors=errors)
+
+        # Guardar
+        code = self.repo.update_initial(
+            id_conjunto=payload.id_conjunto,
+            id_usuario=payload.id_usuario,
+            email=(payload.email.lower().strip() if payload.email else None),
+            nombre_conjunto=payload.nombre_conjunto,
+            ciudad_id=payload.ciudad_id,
+            direccion=payload.direccion,
+            telefono=payload.telefono,
+            cantidad_parqueaderos=payload.cantidad_parqueaderos,
+        )
+
+        if code == 404:
+            return SetupActionResult(status="not_found", message="Conjunto o usuario no encontrado")
+        if code == 409:
+            return SetupActionResult(
+                status="conflict",
+                message="La cantidad de parqueaderos no puede ser menor a la ya asignada en el conjunto"
+            )
+
+        return SetupActionResult(status="ok", message="Datos guardados correctamente")

--- a/app/application/common/use_case/setup_initial.py
+++ b/app/application/common/use_case/setup_initial.py
@@ -26,7 +26,7 @@ class SetupInitialUpdateUseCase:
         self.repo = repo
 
     def execute(self, payload: SetupInitialUpdateIn) -> SetupActionResult:
-        # Validación de “espacios en blanco” (string vacía tras strip)
+        # Validación “espacios en blanco”
         errors: list[FieldError] = []
         def is_blank(s: str | None) -> bool:
             return s is not None and s.strip() == ""
@@ -43,10 +43,8 @@ class SetupInitialUpdateUseCase:
         if errors:
             return SetupActionResult(status="validation_error", message="Datos inválidos", errors=errors)
 
-        # Guardar
         code = self.repo.update_initial(
             id_conjunto=payload.id_conjunto,
-            id_usuario=payload.id_usuario,
             email=(payload.email.lower().strip() if payload.email else None),
             nombre_conjunto=payload.nombre_conjunto,
             ciudad_id=payload.ciudad_id,
@@ -56,7 +54,7 @@ class SetupInitialUpdateUseCase:
         )
 
         if code == 404:
-            return SetupActionResult(status="not_found", message="Conjunto o usuario no encontrado")
+            return SetupActionResult(status="not_found", message="Conjunto no encontrado")
         if code == 409:
             return SetupActionResult(
                 status="conflict",

--- a/app/infrastructure/db/models/model.py
+++ b/app/infrastructure/db/models/model.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import datetime
 
-from sqlalchemy import Boolean, Date, ForeignKeyConstraint, Integer, PrimaryKeyConstraint, String, text
+from sqlalchemy import Boolean, Date, ForeignKeyConstraint, Index, Integer, PrimaryKeyConstraint, String, text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 class Base(DeclarativeBase):
@@ -160,7 +160,9 @@ class Usuario(Base):
         ForeignKeyConstraint(['administracion_id'], ['norma.id_norma'], name='usuario_administracion_id_fkey'),
         ForeignKeyConstraint(['rol_permiso_id'], ['rol_permiso.id_rol_permiso'], name='usuario_rol_permiso_id_fkey'),
         ForeignKeyConstraint(['tipo_usuario_id'], ['tipo_usuario.id_tipo_usuario'], name='usuario_tipo_usuario_id_fkey'),
-        PrimaryKeyConstraint('id_usuario', name='usuario_pkey')
+        PrimaryKeyConstraint('id_usuario', name='usuario_pkey'),
+        Index('uq_usuario_documento', 'documento', unique=True),
+        Index('uq_usuario_email', 'email', unique=True)
     )
 
     id_usuario: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -172,6 +174,8 @@ class Usuario(Base):
     tipo_usuario_id: Mapped[Optional[int]] = mapped_column(Integer)
     rol_permiso_id: Mapped[Optional[int]] = mapped_column(Integer)
     administracion_id: Mapped[Optional[int]] = mapped_column(Integer)
+    email: Mapped[Optional[str]] = mapped_column(String(255))
+    documento: Mapped[Optional[str]] = mapped_column(String(30))
 
     administracion: Mapped[Optional['Norma']] = relationship('Norma', back_populates='usuario')
     rol_permiso: Mapped[Optional['RolPermiso']] = relationship('RolPermiso', back_populates='usuario')

--- a/app/infrastructure/db/models/model.py
+++ b/app/infrastructure/db/models/model.py
@@ -1,7 +1,7 @@
 from typing import Optional
 import datetime
 
-from sqlalchemy import Boolean, Date, ForeignKeyConstraint, Index, Integer, PrimaryKeyConstraint, String, text
+from sqlalchemy import Boolean, CheckConstraint, Date, ForeignKeyConstraint, Index, Integer, PrimaryKeyConstraint, String, text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 class Base(DeclarativeBase):
@@ -11,7 +11,9 @@ class Base(DeclarativeBase):
 class ConjuntoResidencial(Base):
     __tablename__ = 'conjunto_residencial'
     __table_args__ = (
-        PrimaryKeyConstraint('id_conjunto_residencial', name='conjunto_residencial_pkey'),
+        CheckConstraint("email_contacto IS NULL OR email_contacto::text ~* '^[A-Z0-9._%%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$'::text", name='chk_conjunto_email_contacto'),
+        CheckConstraint("telefono_contacto IS NULL OR telefono_contacto::text ~ '^[0-9]{7,15}$'::text", name='chk_conjunto_telefono_contacto'),
+        PrimaryKeyConstraint('id_conjunto_residencial', name='conjunto_residencial_pkey')
     )
 
     id_conjunto_residencial: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -20,6 +22,8 @@ class ConjuntoResidencial(Base):
     numero_torres: Mapped[Optional[int]] = mapped_column(Integer)
     numero_apartamentos: Mapped[Optional[int]] = mapped_column(Integer)
     ciudad_id: Mapped[Optional[int]] = mapped_column(Integer)
+    email_contacto: Mapped[Optional[str]] = mapped_column(String(255))
+    telefono_contacto: Mapped[Optional[str]] = mapped_column(String(15))
 
     apartamento: Mapped[list['Apartamento']] = relationship('Apartamento', back_populates='conjunto_residencial')
     sorteo: Mapped[list['Sorteo']] = relationship('Sorteo', back_populates='conjunto_residencial')

--- a/app/infrastructure/db/repositories/setup_repository.py
+++ b/app/infrastructure/db/repositories/setup_repository.py
@@ -1,0 +1,74 @@
+from typing import Optional, Tuple
+from sqlalchemy.orm import Session
+from sqlalchemy import select, func
+from app.infrastructure.db.models.model import (
+    ConjuntoResidencial, Ciudad, Usuario, Apartamento
+)
+
+class SetupRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def fetch_initial(self, id_conjunto: int, id_usuario: int):
+        usr = self.db.get(Usuario, id_usuario)
+        cjto = self.db.get(ConjuntoResidencial, id_conjunto)
+
+        ciudad_nombre: Optional[str] = None
+        if cjto and cjto.ciudad_id:
+            ciudad = self.db.get(Ciudad, cjto.ciudad_id)
+            ciudad_nombre = ciudad.nombre_ciudad if ciudad else None
+
+        asignados = self.db.scalar(
+            select(func.count(func.distinct(Apartamento.parqueadero_id)))
+            .where(Apartamento.conjunto_residencial_id == id_conjunto)
+            .where(Apartamento.parqueadero_id.isnot(None))
+        ) or 0
+
+        return usr, cjto, ciudad_nombre, asignados
+
+    def update_initial(
+        self,
+        *,
+        id_conjunto: int,
+        id_usuario: int,
+        email: Optional[str],
+        nombre_conjunto: str,
+        ciudad_id: int,
+        direccion: Optional[str],
+        telefono: Optional[str],
+        cantidad_parqueaderos: int,
+    ) -> int:
+        # Validaciones de existencia
+        cjto = self.db.get(ConjuntoResidencial, id_conjunto)
+        if not cjto:
+            return 404
+        usr = self.db.get(Usuario, id_usuario)
+        if not usr:
+            return 404
+
+        # Reglas de negocio
+        asignados = self.db.scalar(
+            select(func.count(func.distinct(Apartamento.parqueadero_id)))
+            .where(Apartamento.conjunto_residencial_id == id_conjunto)
+            .where(Apartamento.parqueadero_id.isnot(None))
+        ) or 0
+        if cantidad_parqueaderos < asignados:
+            return 409
+
+        # Limpieza
+        nombre_conjunto = " ".join(nombre_conjunto.split())
+        direccion = " ".join(direccion.split()) if direccion else None
+        email = email.lower().strip() if email else None
+        telefono = telefono.strip() if telefono else None
+
+        # Persistir en CONJUNTO (ya existen email_contacto y telefono_contacto)
+        cjto.nombre_conjunto = nombre_conjunto
+        cjto.direccion_conjunto = direccion
+        cjto.ciudad_id = ciudad_id
+        cjto.numero_apartamentos = cantidad_parqueaderos
+        cjto.email_contacto = email
+        cjto.telefono_contacto = telefono
+
+        self.db.add(cjto)
+        self.db.flush()
+        return 200

--- a/app/infrastructure/db/repositories/setup_repository.py
+++ b/app/infrastructure/db/repositories/setup_repository.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 from sqlalchemy.orm import Session
 from sqlalchemy import select, func
 from app.infrastructure.db.models.model import (
@@ -30,7 +30,6 @@ class SetupRepository:
         self,
         *,
         id_conjunto: int,
-        id_usuario: int,
         email: Optional[str],
         nombre_conjunto: str,
         ciudad_id: int,
@@ -38,15 +37,10 @@ class SetupRepository:
         telefono: Optional[str],
         cantidad_parqueaderos: int,
     ) -> int:
-        # Validaciones de existencia
         cjto = self.db.get(ConjuntoResidencial, id_conjunto)
         if not cjto:
             return 404
-        usr = self.db.get(Usuario, id_usuario)
-        if not usr:
-            return 404
 
-        # Reglas de negocio
         asignados = self.db.scalar(
             select(func.count(func.distinct(Apartamento.parqueadero_id)))
             .where(Apartamento.conjunto_residencial_id == id_conjunto)
@@ -61,7 +55,7 @@ class SetupRepository:
         email = email.lower().strip() if email else None
         telefono = telefono.strip() if telefono else None
 
-        # Persistir en CONJUNTO (ya existen email_contacto y telefono_contacto)
+        # Persistir en CONJUNTO
         cjto.nombre_conjunto = nombre_conjunto
         cjto.direccion_conjunto = direccion
         cjto.ciudad_id = ciudad_id

--- a/app/infrastructure/db/repositories/usuario_respository.py
+++ b/app/infrastructure/db/repositories/usuario_respository.py
@@ -1,0 +1,75 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import select, update
+from app.infrastructure.db.models.model import Usuario
+
+class UsuariosRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    # ---------- NUEVO ----------
+    def upsert_first_time(self, *, documento: str, nombre: str, apellidos: str,
+                          telefono: str, email: str, contrasena: str) -> Usuario:
+        """
+        Crea o actualiza un usuario para el registro first-time.
+        Criterio de upsert: documento OR email.
+        Marca first_time=True.
+        """
+        doc = documento.strip()
+        eml = email.lower().strip()
+
+        stmt = select(Usuario).where(
+            (Usuario.documento == doc) | (Usuario.email == eml)
+        ).limit(1)
+        user = self.db.execute(stmt).scalars().first()
+
+        if user:
+            user.nombre = nombre.strip()
+            user.apellidos = apellidos.strip()
+            user.telefono = telefono.strip()
+            user.email = eml
+            user.contrasena = contrasena.strip()
+            user.first_time = True
+            self.db.add(user)
+            self.db.flush()
+            return user
+
+        user = Usuario(
+            documento=doc,
+            nombre=nombre.strip(),
+            apellidos=apellidos.strip(),
+            telefono=telefono.strip(),
+            email=eml,
+            contrasena=contrasena.strip(),
+            first_time=True,
+        )
+        self.db.add(user)
+        self.db.flush()
+        return user
+    # ---------------------------
+
+    def get_by_email_and_pass(self, email: str, contrasena: str) -> Usuario | None:
+        stmt = select(Usuario).where(
+            Usuario.email == email.lower().strip(),
+            Usuario.contrasena == contrasena.strip()
+        ).limit(1)
+        return self.db.execute(stmt).scalars().first()
+
+    def disable_first_time(self, user_id: int) -> None:
+        self.db.execute(
+            update(Usuario)
+            .where(Usuario.id_usuario == user_id)
+            .values(first_time=False)
+        )
+        self.db.flush()
+
+    def set_first_time(self, user_id: int, first_time: bool) -> int:
+        res = self.db.execute(
+            update(Usuario)
+            .where(Usuario.id_usuario == user_id)
+            .values(first_time=first_time)
+            .execution_options(synchronize_session="fetch")
+        )
+        return res.rowcount
+
+    def get_by_id(self, user_id: int) -> Usuario | None:
+        return self.db.get(Usuario, user_id)

--- a/app/infrastructure/db/repositories/usuario_respository.py
+++ b/app/infrastructure/db/repositories/usuario_respository.py
@@ -1,75 +1,35 @@
 from sqlalchemy.orm import Session
-from sqlalchemy import select, update
-from app.infrastructure.db.models.model import Usuario
+from sqlalchemy import select
+from typing import Optional, Tuple
+
+from app.infrastructure.db.models.model import Usuario, Apartamento  # Apartamento tiene conjunto_residencial_id :contentReference[oaicite:2]{index=2}
 
 class UsuariosRepository:
     def __init__(self, db: Session):
         self.db = db
 
-    # ---------- NUEVO ----------
-    def upsert_first_time(self, *, documento: str, nombre: str, apellidos: str,
-                          telefono: str, email: str, contrasena: str) -> Usuario:
-        """
-        Crea o actualiza un usuario para el registro first-time.
-        Criterio de upsert: documento OR email.
-        Marca first_time=True.
-        """
-        doc = documento.strip()
-        eml = email.lower().strip()
-
-        stmt = select(Usuario).where(
-            (Usuario.documento == doc) | (Usuario.email == eml)
-        ).limit(1)
-        user = self.db.execute(stmt).scalars().first()
-
-        if user:
-            user.nombre = nombre.strip()
-            user.apellidos = apellidos.strip()
-            user.telefono = telefono.strip()
-            user.email = eml
-            user.contrasena = contrasena.strip()
-            user.first_time = True
-            self.db.add(user)
-            self.db.flush()
-            return user
-
-        user = Usuario(
-            documento=doc,
-            nombre=nombre.strip(),
-            apellidos=apellidos.strip(),
-            telefono=telefono.strip(),
-            email=eml,
-            contrasena=contrasena.strip(),
-            first_time=True,
-        )
-        self.db.add(user)
-        self.db.flush()
-        return user
-    # ---------------------------
-
-    def get_by_email_and_pass(self, email: str, contrasena: str) -> Usuario | None:
+    def get_by_email_and_pass(self, email: str, contrasena: str) -> Optional[Usuario]:
+        # Si tu tabla usuario NO tiene email todavía, comenta este método y usa el de teléfono.
         stmt = select(Usuario).where(
             Usuario.email == email.lower().strip(),
             Usuario.contrasena == contrasena.strip()
         ).limit(1)
         return self.db.execute(stmt).scalars().first()
 
-    def disable_first_time(self, user_id: int) -> None:
-        self.db.execute(
-            update(Usuario)
-            .where(Usuario.id_usuario == user_id)
-            .values(first_time=False)
-        )
-        self.db.flush()
+    def get_by_phone_and_pass(self, telefono: str, contrasena: str) -> Optional[Usuario]:
+        # Fallback si aún no tienes email en BD/ORM
+        stmt = select(Usuario).where(
+            Usuario.telefono == telefono.strip(),
+            Usuario.contrasena == contrasena.strip()
+        ).limit(1)
+        return self.db.execute(stmt).scalars().first()
 
-    def set_first_time(self, user_id: int, first_time: bool) -> int:
-        res = self.db.execute(
-            update(Usuario)
-            .where(Usuario.id_usuario == user_id)
-            .values(first_time=first_time)
-            .execution_options(synchronize_session="fetch")
+    def get_conjunto_id_for_user(self, user_id: int) -> Optional[int]:
+        # Apartamento.usuario_id -> Apartamento.conjunto_residencial_id (JOIN implícito)
+        stmt = (
+            select(Apartamento.conjunto_residencial_id)
+            .where(Apartamento.usuario_id == user_id)
+            .limit(1)
         )
-        return res.rowcount
-
-    def get_by_id(self, user_id: int) -> Usuario | None:
-        return self.db.get(Usuario, user_id)
+        res = self.db.execute(stmt).scalar_one_or_none()
+        return res

--- a/app/infrastructure/db/session.py
+++ b/app/infrastructure/db/session.py
@@ -1,6 +1,17 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from app.settings import DATABASE_URL
+
+if not DATABASE_URL:
+    raise ValueError("DATABASE_URL no está definida. Verifica tu archivo .env o variables de entorno.")
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/infrastructure/repositories/usuario_repository.py
+++ b/app/infrastructure/repositories/usuario_repository.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+from sqlalchemy import select, update
+from app.infrastructure.db.models.model import Usuario  # usa tu modelo ya generado
+
+class UsuariosRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_by_phone_and_pass(self, telefono: str, contrasena: str) -> Usuario | None:
+        telefono = " ".join(telefono.strip().split())
+        contrasena = contrasena.strip()
+        stmt = (
+            select(Usuario)
+            .where(Usuario.telefono == telefono)
+            .where(Usuario.contrasena == contrasena)
+            .limit(1)
+        )
+        return self.db.scalar(stmt)
+
+    def set_first_time(self, user_id: int, first_time: bool) -> int:
+        res = self.db.execute(
+            update(Usuario)
+            .where(Usuario.id_usuario == user_id)
+            .values(first_time=first_time)
+            .execution_options(synchronize_session="fetch")
+        )
+        return res.rowcount
+
+    def get_by_id(self, user_id: int) -> Usuario | None:
+        return self.db.get(Usuario, user_id)

--- a/app/interfaces/routers/auth.py
+++ b/app/interfaces/routers/auth.py
@@ -29,11 +29,8 @@ def first_time_register(payload: FirstTimeRegisterIn, db: Session = Depends(get_
 def login(payload: LoginIn, db: Session = Depends(get_db)):
     try:
         out = AuthLoginUseCase(UsuariosRepository(db)).execute(payload)
-        db.commit()  # si dentro del use case pones disable_first_time
         return out
     except ValueError as ve:
-        db.rollback()
         raise HTTPException(status_code=401, detail=str(ve))
     except Exception as e:
-        db.rollback()
         raise HTTPException(status_code=500, detail=f"Error en login: {type(e).__name__}: {e}")

--- a/app/interfaces/routers/auth.py
+++ b/app/interfaces/routers/auth.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.infrastructure.db.session import get_db
+from app.application.common.use_case.schemas.auth import (
+    FirstTimeRegisterIn, LoginIn, LoginOut
+)
+from app.infrastructure.db.repositories.usuario_respository import UsuariosRepository
+from app.application.common.use_case.auth_first_time_register import FirstTimeRegisterUseCase
+from app.application.common.use_case.schemas.auth_login import AuthLoginUseCase
+
+router = APIRouter(prefix="/auth", tags=["Auth"])
+
+@router.post("/first-time", response_model=LoginOut, status_code=status.HTTP_201_CREATED)
+def first_time_register(payload: FirstTimeRegisterIn, db: Session = Depends(get_db)):
+    try:
+        out = FirstTimeRegisterUseCase(UsuariosRepository(db)).execute(payload)
+        db.commit()
+        return out  # first_time: true
+    except ValueError as ve:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(ve))
+    except Exception as e:
+        db.rollback()
+        # En desarrollo puedes devolver e para ver el motivo exacto
+        raise HTTPException(status_code=500, detail=f"Error en registro first-time: {type(e).__name__}: {e}")
+
+@router.post("/login", response_model=LoginOut, status_code=status.HTTP_200_OK)
+def login(payload: LoginIn, db: Session = Depends(get_db)):
+    try:
+        out = AuthLoginUseCase(UsuariosRepository(db)).execute(payload)
+        db.commit()  # si dentro del use case pones disable_first_time
+        return out
+    except ValueError as ve:
+        db.rollback()
+        raise HTTPException(status_code=401, detail=str(ve))
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Error en login: {type(e).__name__}: {e}")

--- a/app/interfaces/routers/setup.py
+++ b/app/interfaces/routers/setup.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.orm import Session
+from app.infrastructure.db.session import get_db
+
+from app.application.common.use_case.schemas.setup import (
+    SetupInitialOut, SetupInitialUpdateIn, SetupActionResult
+)
+from app.infrastructure.db.repositories.setup_repository import SetupRepository
+from app.application.common.use_case.setup_initial import (
+    SetupInitialGetUseCase, SetupInitialUpdateUseCase
+)
+
+router = APIRouter(prefix="/setup", tags=["Setup"])
+
+@router.get("/initial", response_model=SetupInitialOut)
+def get_initial_config(
+    id_conjunto: int = Query(..., gt=0),
+    id_usuario: int = Query(..., gt=0),
+    db: Session = Depends(get_db)
+):
+    try:
+        uc = SetupInitialGetUseCase(SetupRepository(db))
+        return uc.execute(id_conjunto, id_usuario)
+    except ValueError as ve:
+        raise HTTPException(status_code=404, detail=str(ve))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error al consultar configuración: {type(e).__name__}: {e}")
+
+@router.patch("/initial", response_model=SetupActionResult, status_code=status.HTTP_200_OK)
+def patch_initial_config(payload: SetupInitialUpdateIn, db: Session = Depends(get_db)):
+    try:
+        uc = SetupInitialUpdateUseCase(SetupRepository(db))
+        result = uc.execute(payload)
+        # commit solo si guardó (status ok)
+        if result.status == "ok":
+            db.commit()
+        else:
+            db.rollback()
+        return result
+    except Exception as e:
+        db.rollback()
+        return SetupActionResult(
+            status="error",
+            message=f"Error al guardar configuración: {type(e).__name__}: {e}"
+        )

--- a/app/interfaces/routers/setup.py
+++ b/app/interfaces/routers/setup.py
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/setup", tags=["Setup"])
 @router.get("/initial", response_model=SetupInitialOut)
 def get_initial_config(
     id_conjunto: int = Query(..., gt=0),
-    id_usuario: int = Query(..., gt=0),
+    id_usuario: int = Query(..., gt=0),   # <- si luego quieres, lo quitamos también del GET
     db: Session = Depends(get_db)
 ):
     try:
@@ -31,7 +31,6 @@ def patch_initial_config(payload: SetupInitialUpdateIn, db: Session = Depends(ge
     try:
         uc = SetupInitialUpdateUseCase(SetupRepository(db))
         result = uc.execute(payload)
-        # commit solo si guardó (status ok)
         if result.status == "ok":
             db.commit()
         else:

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.infrastructure.db.base import Base
 from app.infrastructure.db.session import engine
 from app.interfaces.routers.auth import router as auth_router
+from app.interfaces.routers.setup import router as setup_router
+
 
 app = FastAPI(title="SIPAR API")
 
@@ -16,3 +18,4 @@ app.add_middleware(
 
 Base.metadata.create_all(bind=engine)
 app.include_router(auth_router)
+app.include_router(setup_router)

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,18 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from app.infrastructure.db.base import Base
+from app.infrastructure.db.session import engine
+from app.interfaces.routers.auth import router as auth_router
 
-app = FastAPI()
+app = FastAPI(title="SIPAR API")
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],  # ajusta a tu front
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+Base.metadata.create_all(bind=engine)
+app.include_router(auth_router)


### PR DESCRIPTION
## Contexto  
Como administrador del conjunto, quiero confirmar o modificar los datos básicos (nombre, dirección, ciudad, teléfonos, correo) para garantizar que la configuración inicial sea precisa. ✍️✅

## Cambios principales  
- Backend:  
  - `GET /setup/initial` devuelve datos del conjunto + `primera_vez: true` en primer login.  
  - `PATCH /setup/initial` para actualizar nombre, dirección, ciudad, teléfonos, correo.  
  - Validaciones (obligatorios y formatos), transacción/atomicidad y manejo de errores (4xx validación, 5xx internos).  
- Frontend:  
  - Formulario con estados de carga/éxito/error y mensajes claros.  
  - Deshabilitar “Confirmar” mientras se edita/valida y al enviar.  
  - Normalización de entradas (trim, lower/upper donde aplique).

## Cómo probar (QA)  
1. **Primer login**  
   - Autenticar admin sin configuración confirmada.  
   - Esperado: `GET /setup/initial` → `200` con datos precargados y `primera_vez: true`. 🟢  

2. **Actualización exitosa**  
   - Enviar `PATCH /setup/initial` con datos válidos (mín. 1 teléfono y correo válido).  
   - Esperado: `200` con confirmación y datos persistidos. 🎉  

3. **Validación de campos**  
   - Enviar con nombre vacío / correo inválido / sin teléfonos.  
   - Esperado: `400` con mensajes específicos por campo, sin cambios en BD. 🚫  

4. **Error interno/BD**  
   - Forzar fallo (p.ej., simular excepción).  
   - Esperado: `500`, sin modificar datos previos. 🛑  

5. **Idempotencia visual**  
   - Reabrir formulario: ver datos actualizados y botón “Confirmar” habilitado solo si hay cambios válidos.

## Datos de ejemplo  

### Request (PATCH)  
```json
{
  "nombre": "Conjunto Villa Verde",
  "direccion": "Carrera 10 #20-30",
  "ciudad_id": 2,
  "telefonos": ["3122775566", "6011234567"],
  "correo": "contacto@villaverde.com"
}