### PR TITLE
UH-3B-Config-Sorteo

### DIFF
--- a/app/application/common/use_case/schemas/schema_sorteo.py
+++ b/app/application/common/use_case/schemas/schema_sorteo.py
@@ -44,7 +44,6 @@ class ConfigIn(BaseModel):
     )
     normas: List[ReglaIn] = Field(..., description="Listado de normas a aplicar")
 
-    # 👇 Esto hace que Swagger muestre ejemplos listos para usar
     model_config = ConfigDict(
         json_schema_extra={
             "examples": [
@@ -87,7 +86,6 @@ class ConfigIn(BaseModel):
     )
 
 
-# ------- RESPUESTA -------
 
 class ReglaOut(BaseModel):
     tipo: ReglaTipoEnum
@@ -98,26 +96,24 @@ class ConfigOut(BaseModel):
     id_sorteo: int
     conjunto_id: int
     periodicidad: PeriodicidadEnum
+    sequence_id: int            
     fechas_programadas: List[datetime]
     reglas_asignadas: List[ReglaOut]
 
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "id_sorteo": 1,
-                "conjunto_id": 1,
-                "periodicidad": "TRIMESTRAL",
-                "fechas_programadas": [
-                    "2026-01-15T00:00:00",
-                    "2026-04-15T00:00:00",
-                    "2026-07-15T00:00:00",
-                    "2026-10-15T00:00:00"
-                ],
-                "reglas_asignadas": [
-                    {"tipo": "PRIORIDAD_PROPIETARIO"},
-                    {"tipo": "PAGO_ADMINISTRACION"},
-                    {"tipo": "ROTACION", "parametros": {"n": 3}}
-                ]
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "id_sorteo": 1,
+            "conjunto_id": 1,
+            "periodicidad": "TRIMESTRAL",
+            "sequence_id": 2,     
+            "fechas_programadas": [
+                "2026-01-15T00:00:00","2026-04-15T00:00:00",
+                "2026-07-15T00:00:00","2026-10-15T00:00:00"
+            ],
+            "reglas_asignadas": [
+                {"tipo": "PRIORIDAD_PROPIETARIO"},
+                {"tipo": "PAGO_ADMINISTRACION"},
+                {"tipo": "ROTACION", "parametros": {"n": 3}}
+            ]
         }
-    )
+    })

--- a/app/application/common/use_case/sorteo_usecase.py
+++ b/app/application/common/use_case/sorteo_usecase.py
@@ -1,31 +1,41 @@
 from datetime import datetime
-from app.domain.usuarios.dates import fechas_ciclo          
+from app.domain.usuarios.dates import fechas_ciclo
 from app.domain.Exeptions.exceptions import DomainError
-        
+from app.infrastructure.repositories.sorteo_repository import SorteoRepo
 
-class CreateSorteoConfig:
-    def __init__(self, repo):
+class UpsertSorteoConfig:
+    def __init__(self, repo: SorteoRepo):
         self.repo = repo
 
     def __call__(self, conjunto_id: int, periodicidad: str, fecha_inicio: str, normas: list):
-        # Parse ISO (maneja 'Z' si llegara): "2026-02-01T00:00:00" OK
         try:
-            # Si usas 'Z' en el ISO, haz un replace('Z','') o usa dateutil.parser.parse
-            dt0 = datetime.fromisoformat(fecha_inicio.replace('Z',''))
+            dt0 = datetime.fromisoformat(fecha_inicio.replace("Z",""))
         except Exception as e:
-            raise DomainError(400, "ERR_FECHA_INVALIDA", f"Formato de fecha_inicio inválido: {e}")
+            raise DomainError(400, "ERR_FECHA_INVALIDA", f"Formato inválido en fecha_inicio: {e}")
 
-        # Cálculo de fechas
         try:
             fechas = fechas_ciclo(dt0, periodicidad)
-        except ValueError as e:
-            # periodicidad fuera del dominio
-            raise DomainError(400, "ERR_PERIODICIDAD_DESCONOCIDA", str(e))
+        except ValueError:
+            raise DomainError(400, "ERR_PERIODICIDAD_DESCONOCIDA",
+                              "La periodicidad debe ser TRIMESTRAL, CUATRIMESTRAL o SEMESTRAL.")
 
-        # ... aquí tu lógica de persistencia ...
-        sid = self.repo.crear_sorteo(conjunto_id, periodicidad)
+
+        row = self.repo.obtener_sorteo_por_conjunto_for_update(conjunto_id)
+
+        if row is None:
+            meta = self.repo.crear_sorteo(conjunto_id, periodicidad)
+            sid, sequence_id = meta["id_sorteo"], meta["sequence_id"]
+        else:
+            # actualizar y subir sequence_id
+            sid = row["id_sorteo"]
+            sequence_id = self.repo.actualizar_incrementando_sequence(sid, periodicidad)
+            # reemplazar fechas / normas
+            self.repo.borrar_fechas(sid)
+            self.repo.borrar_normas(sid)
+
+        # insertar nuevas fechas y normas
         self.repo.insertar_fechas(sid, fechas)
         self.repo.insertar_normas(sid, normas)
-        self.repo.commit()
 
-        return sid, fechas
+        self.repo.commit()
+        return sid, fechas, sequence_id

--- a/app/infrastructure/repositories/sorteo_repository.py
+++ b/app/infrastructure/repositories/sorteo_repository.py
@@ -1,46 +1,72 @@
+from typing import Optional, List, Dict
 from sqlalchemy import text
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
 from app.domain.Exeptions.exceptions import DomainError
 
 class SorteoRepo:
     def __init__(self, session: Session):
         self.session = session
 
-    def crear_sorteo(self, conjunto_id: int, periodicidad: str) -> int:
+    # ----- Lectura/lock -----
+    def obtener_sorteo_por_conjunto_for_update(self, conjunto_id: int) -> Optional[dict]:
+        q = text("""
+            SELECT id_sorteo, conjunto_residencial_id, periodicidad, sequence_id
+            FROM public.sorteo
+            WHERE conjunto_residencial_id = :cid
+            FOR UPDATE
+        """)
+        row = self.session.execute(q, {"cid": conjunto_id}).mappings().first()
+        return dict(row) if row else None
+
+    # ----- Crear -----
+    def crear_sorteo(self, conjunto_id: int, periodicidad: str) -> dict:
         q = text("""
             INSERT INTO public.sorteo (conjunto_residencial_id, periodicidad)
             VALUES (:cid, :per)
-            RETURNING id_sorteo
+            RETURNING id_sorteo, sequence_id
         """)
         try:
-            return self.session.execute(q, {"cid": conjunto_id, "per": periodicidad}).scalar_one()
+            row = self.session.execute(q, {"cid": conjunto_id, "per": periodicidad}).mappings().one()
+            return {"id_sorteo": row["id_sorteo"], "sequence_id": row["sequence_id"]}
         except IntegrityError as e:
-            # Importante: revertir la transacción antes de relanzar
+            # debería ser raro porque hacemos FOR UPDATE antes, pero por seguridad
             self.session.rollback()
-            # Detecta tu constraint por nombre o por mensaje
-            if "uniq_sorteo_conjunto" in str(e.orig) or "conjunto_residencial_id" in str(e.orig):
-                raise DomainError(
-                    409,
-                    "ERR_SORTEO_DUPLICADO_CONJUNTO",
-                    "Ya existe un sorteo configurado para este conjunto."
-                ) from e
-            raise
+            raise DomainError(409, "ERR_SORTEO_DUPLICADO_CONJUNTO",
+                              "Ya existe un sorteo configurado para este conjunto.") from e
 
-    def insertar_fechas(self, sorteo_id: int, fechas: list):
-        if not fechas: 
-            return
+    # ----- Actualizar + incrementar sequence -----
+    def actualizar_incrementando_sequence(self, sorteo_id: int, periodicidad: str) -> int:
+        q = text("""
+            UPDATE public.sorteo
+            SET periodicidad = :per,
+                sequence_id   = sequence_id + 1
+            WHERE id_sorteo = :sid
+            RETURNING sequence_id
+        """)
+        new_seq = self.session.execute(q, {"per": periodicidad, "sid": sorteo_id}).scalar_one()
+        return int(new_seq)
+
+    # ----- Fechas / Normas -----
+    def borrar_fechas(self, sorteo_id: int):
+        self.session.execute(text("DELETE FROM public.sorteo_fecha WHERE sorteo_id = :sid"), {"sid": sorteo_id})
+
+    def insertar_fechas(self, sorteo_id: int, fechas: List):
+        if not fechas: return
         q = text("INSERT INTO public.sorteo_fecha (sorteo_id, fecha) VALUES (:sid, :fecha)")
         self.session.execute(q, [{"sid": sorteo_id, "fecha": f} for f in fechas])
 
-    def mapear_norma_por_nombre(self, nombre_normalizado: str):
+    def borrar_normas(self, sorteo_id: int):
+        self.session.execute(text("DELETE FROM public.sorteo_norma WHERE sorteo_id = :sid"), {"sid": sorteo_id})
+
+    def mapear_norma_por_nombre(self, nombre_normalizado: str) -> Optional[int]:
         normadb = 'ROTACIÓN' if nombre_normalizado == 'ROTACION' else nombre_normalizado
         q = text("SELECT id_norma FROM public.norma WHERE UPPER(nombre_norma)=UPPER(:n) LIMIT 1")
         return self.session.execute(q, {"n": normadb}).scalar_one_or_none()
 
-    def insertar_normas(self, sorteo_id: int, normas: list[dict]):
+    def insertar_normas(self, sorteo_id: int, normas: List[Dict]):
         for n in normas:
-            if not n.get("activa"):
+            if not n.get("activa"): 
                 continue
             nid = self.mapear_norma_por_nombre(n.get("tipo","").strip().upper())
             if nid is None:
@@ -48,15 +74,10 @@ class SorteoRepo:
             parametro = None
             if n.get("tipo") == "ROTACION" and n.get("parametros"):
                 parametro = str(n["parametros"].get("n")) if n["parametros"].get("n") is not None else None
-            q = text("""
+            self.session.execute(text("""
                 INSERT INTO public.sorteo_norma (sorteo_id, norma_id, parametro)
                 VALUES (:sid, :nid, :parametro)
-                ON CONFLICT (sorteo_id, norma_id) DO UPDATE SET parametro = EXCLUDED.parametro
-            """)
-            self.session.execute(q, {"sid": sorteo_id, "nid": nid, "parametro": parametro})
+            """), {"sid": sorteo_id, "nid": nid, "parametro": parametro})
 
-    def commit(self):
-        self.session.commit()
-
-    def rollback(self):
-        self.session.rollback()
+    def commit(self): self.session.commit()
+    def rollback(self): self.session.rollback()

--- a/app/interfaces/routers/sorteo_router.py
+++ b/app/interfaces/routers/sorteo_router.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Body
 from app.application.common.use_case.schemas.schema_sorteo import ConfigIn, ConfigOut, ReglaOut
 from app.infrastructure.db.dependencies import get_repo
 from app.infrastructure.repositories.sorteo_repository import SorteoRepo
-from app.application.common.use_case.sorteo_usecase import CreateSorteoConfig
+from app.application.common.use_case.sorteo_usecase import UpsertSorteoConfig
 from app.domain.Exeptions.exceptions import DomainError
 
 router = APIRouter(prefix="/api/v1/conjuntos", tags=["sorteos"])
@@ -12,24 +12,23 @@ router = APIRouter(prefix="/api/v1/conjuntos", tags=["sorteos"])
     "/{id_conjunto}/sorteos/configuracion",
     response_model=ConfigOut,
     status_code=201,
-    summary="Crear Config",
-    description="Crea la configuración del sorteo (periodicidad, fecha de inicio y normas)."
+    summary="Crear/Actualizar configuración del sorteo (upsert)",
+    description="Si no existe sorteo para el conjunto: crea (sequence_id=1). Si existe: actualiza y aumenta sequence_id en 1."
 )
-def crear_config(
+def upsert_config(
     id_conjunto: int = Path(..., ge=1),
     body: ConfigIn = Body(...)
     ,
     repo: SorteoRepo = Depends(get_repo)
 ):
     try:
-        sid, fechas = CreateSorteoConfig(repo)(
+        sid, fechas, seq = UpsertSorteoConfig(repo)(
             conjunto_id=id_conjunto,
             periodicidad=body.periodicidad.value,
             fecha_inicio=body.fecha_inicio.isoformat(),
             normas=[n.model_dump() for n in body.normas]
         )
 
-        # construir reglas_asignadas para la salida
         reglas: list[ReglaOut] = []
         for n in body.normas:
             if not n.activa:
@@ -43,10 +42,10 @@ def crear_config(
             id_sorteo=sid,
             conjunto_id=id_conjunto,
             periodicidad=body.periodicidad,
+            sequence_id=seq,             
             fechas_programadas=fechas,
             reglas_asignadas=reglas
         )
 
     except DomainError as e:
-        # Si no tienes un handler global
         raise HTTPException(status_code=e.status, detail={"code": e.code, "message": e.message})


### PR DESCRIPTION
## 🧾 Pull Request — HU: Configurar Sorteo

### 🎯 Descripción General
Se implementa el **servicio de configuración del sorteo** que permite crear o actualizar la configuración asociada a un conjunto residencial.  
El servicio gestiona la periodicidad, fecha de inicio y reglas (con parámetro `n` para la norma ROTACIÓN), dejando listas las fechas y normas correspondientes en base de datos.

### 🧠 Cambios principales
- Creación del endpoint:  
  `POST /api/v1/conjuntos/{id_conjunto}/sorteos/configuracion`
- Inserción del registro principal en la tabla `sorteo`.
- Cálculo automático de fechas según la periodicidad (`TRIMESTRAL`, `CUATRIMESTRAL`, `SEMESTRAL`).
- Inserciones en `sorteo_fecha` con `estado = false`.
- Registro de normas en `sorteo_norma`, validando los parámetros según tipo de norma.
- Asociación automática con el conjunto recibido en el path.
- Manejo de `sequence_id` para distinguir configuraciones sucesivas.

### 🧩 Validaciones incluidas
- La norma **ROTACIÓN** requiere parámetro `n`.
- Periodicidad restringida al ENUM definido.
- Verificación de existencia previa de sorteo (modo PUT implícito).
- Incremento automático del `sequence_id`.

### ✅ Resultado esperado
El sistema deja configurado correctamente un sorteo completo, con fechas programadas, normas registradas y trazabilidad garantizada.

### 🧱 Evidencias
- Pruebas locales de inserción y actualización completadas.
- Validación de respuesta estructurada para consumo en frontend.
- Documentación actualizada en Swagger.

---
👷‍♂️ **Autor:**  Nicolas Cardenas
📅 **Feature:** Configuración de Sorteos  
🧩 **Tarea asociada:** Desarrollo del Servicio de Configuración del Sorteo